### PR TITLE
[metafmt.el] Remove redundant mention of Emacs in description

### DIFF
--- a/metafmt.el
+++ b/metafmt.el
@@ -1,4 +1,4 @@
-;;; metafmt.el --- Emacs interface for metafmt
+;;; metafmt.el --- Run metafmt on buffers when saving them
 
 ;; Copyright (C) 2015 Lorenzo Villani
 ;;


### PR DESCRIPTION
In connection with https://github.com/milkypostman/melpa/pull/3535