### PR TITLE
Add support for Ruby via rubocop --auto-complete

### DIFF
--- a/metafmt.go
+++ b/metafmt.go
@@ -49,11 +49,11 @@ type installMap map[string][]string
 type syntaxMap map[string][]string
 
 type formatter struct {
-	Commands   [][]string
-	Extensions []string
-	Install    installMap
-	Syntaxes   syntaxMap
-	Processor  func([]byte) ([]byte, error)
+	Commands      [][]string
+	Extensions    []string
+	Install       installMap
+	Syntaxes      syntaxMap
+	PostProcessor func([]byte) ([]byte, error)
 }
 
 var formatters = []*formatter{
@@ -155,7 +155,7 @@ var formatters = []*formatter{
 			EMACS:   []string{"ruby-mode"},
 			SUBLIME: []string{"Ruby"},
 		},
-		Processor: func(formatted []byte) ([]byte, error) {
+		PostProcessor: func(formatted []byte) ([]byte, error) {
 			sep := []byte("====================\n")
 			parts := bytes.SplitN(formatted, sep, 2)
 			return parts[1], nil
@@ -435,8 +435,8 @@ func formatChain(dst io.Writer, src io.Reader, formatter *formatter) error {
 		}
 	}
 
-	if formatter.Processor != nil {
-		formatted, err := formatter.Processor(buf.Bytes())
+	if formatter.PostProcessor != nil {
+		formatted, err := formatter.PostProcessor(buf.Bytes())
 		if err != nil {
 			return err
 		}

--- a/metafmt.go
+++ b/metafmt.go
@@ -142,6 +142,25 @@ var formatters = []*formatter{
 			SUBLIME: []string{"Python"},
 		},
 	},
+	// Ruby
+	{
+		Commands: [][]string{
+			[]string{"rubocop", "--stdin", "--cache", "false", "--auto-correct", "--format", "emacs", "fake.rb"},
+		},
+		Install: installMap{
+			"any": []string{"gem", "install", "rubocop"},
+		},
+		Extensions: []string{".rb"},
+		Syntaxes: syntaxMap{
+			EMACS:   []string{"ruby-mode"},
+			SUBLIME: []string{"Ruby"},
+		},
+		Processor: func(formatted []byte) ([]byte, error) {
+			sep := []byte("====================\n")
+			parts := bytes.SplitN(formatted, sep, 2)
+			return parts[1], nil
+		},
+	},
 	// SASS
 	{
 		Commands: [][]string{

--- a/metafmt.go
+++ b/metafmt.go
@@ -436,12 +436,12 @@ func formatChain(dst io.Writer, src io.Reader, formatter *formatter) error {
 	}
 
 	if formatter.Processor != nil {
-		bytes, err := formatter.Processor(buf.Bytes())
+		formatted, err := formatter.Processor(buf.Bytes())
 		if err != nil {
 			return err
 		}
 
-		dst.Write(bytes)
+		dst.Write(formatted)
 		return nil
 	}
 


### PR DESCRIPTION
This is a bit of a quick hack during lunch, so feel free to criticise :)

Thanks to Rubocop always printing a list of issues/fixes, followed by `====================\n` before the corrected file content, I had to add a post processor concept where I can split rubocop's output and only return the file content.